### PR TITLE
samples: matter: Added subscriptions and data providers to bridge

### DIFF
--- a/samples/matter/bridge/CMakeLists.txt
+++ b/samples/matter/bridge/CMakeLists.txt
@@ -53,15 +53,24 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
 endif()
 
 if(CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE)
-    target_sources(app PRIVATE src/bridged_device_types/onoff_light.cpp)
+    target_sources(app PRIVATE
+        src/bridged_device_types/onoff_light.cpp
+        src/bridged_device_types/onoff_light_data_provider.cpp
+    )
 endif()
 
 if(CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE)
-    target_sources(app PRIVATE src/bridged_device_types/temperature_sensor.cpp)
+    target_sources(app PRIVATE
+            src/bridged_device_types/temperature_sensor.cpp
+            src/bridged_device_types/temperature_sensor_data_provider.cpp
+    )
 endif()
 
 if(CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE)
-    target_sources(app PRIVATE src/bridged_device_types/humidity_sensor.cpp)
+    target_sources(app PRIVATE
+        src/bridged_device_types/humidity_sensor.cpp
+        src/bridged_device_types/humidity_sensor_data_provider.cpp
+    )
 endif()
 
 chip_configure_data_model(app

--- a/samples/matter/bridge/Kconfig
+++ b/samples/matter/bridge/Kconfig
@@ -9,6 +9,10 @@ config BRIDGE_MAX_DYNAMIC_ENDPOINTS_NUMBER
 	int "Maximum number of dynamic endpoints supported by the Bridge"
 	default 16
 
+config BRIDGE_MAX_BRIDGED_DEVICES_NUMBER
+	int "Maximum number of physical non-Matter devices supported by the Bridge"
+	default 16
+
 config BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
 	bool "OnOff Light Bridged Device support"
 	default y
@@ -20,6 +24,30 @@ config BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
 config BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
 	bool "Humidity Sensor Bridged Device support"
 	default y
+
+if BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
+
+config BRIDGE_TEMPERATURE_SENSOR_MIN_MEASURED_VALUE
+	int "Default minimum measured value allowed by the bridged temperature sensor device."
+	default -20
+
+config BRIDGE_TEMPERATURE_SENSOR_MAX_MEASURED_VALUE
+	int "Default maximum measured value allowed by the bridged temperature sensor device."
+	default 60
+
+endif
+
+if BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
+
+config BRIDGE_HUMIDITY_SENSOR_MIN_MEASURED_VALUE
+	int "Default minimum measured value allowed by the bridged humidity sensor device."
+	default 0
+
+config BRIDGE_HUMIDITY_SENSOR_MAX_MEASURED_VALUE
+	int "Default maximum measured value allowed by the bridged humidity sensor device."
+	default 100
+
+endif
 
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"

--- a/samples/matter/bridge/src/bridge_manager.h
+++ b/samples/matter/bridge/src/bridge_manager.h
@@ -7,37 +7,34 @@
 #pragma once
 
 #include "bridged_device.h"
-
-#if CONFIG_BRIDGE_ONOFF_LIGHT_BRIDGED_DEVICE
-#include "onoff_light.h"
-#endif
-
-#if CONFIG_BRIDGE_TEMPERATURE_SENSOR_BRIDGED_DEVICE
-#include "temperature_sensor.h"
-#endif
-
-#if CONFIG_BRIDGE_HUMIDITY_SENSOR_BRIDGED_DEVICE
-#include "humidity_sensor.h"
-#endif
+#include "bridged_device_data_provider.h"
+#include <map>
 
 class BridgeManager {
 public:
 	void Init();
 	CHIP_ERROR AddBridgedDevice(BridgedDevice::DeviceType bridgedDeviceType, const char *nodeLabel);
 	CHIP_ERROR RemoveBridgedDevice(uint16_t endpoint);
-	static BridgedDevice * GetBridgedDevice(uint16_t endpoint, const EmberAfAttributeMetadata *attributeMetadata, uint8_t *buffer);
+	static BridgedDevice *GetBridgedDevice(uint16_t endpoint, const EmberAfAttributeMetadata *attributeMetadata,
+					       uint8_t *buffer);
 	static CHIP_ERROR HandleRead(uint16_t endpoint, chip::ClusterId clusterId,
 				     const EmberAfAttributeMetadata *attributeMetadata, uint8_t *buffer,
 				     uint16_t maxReadLength);
 	static CHIP_ERROR HandleWrite(uint16_t endpoint, chip::ClusterId clusterId,
 				      const EmberAfAttributeMetadata *attributeMetadata, uint8_t *buffer);
+	static void HandleUpdate(BridgedDeviceDataProvider &dataProvider, chip::ClusterId clusterId,
+				 chip::AttributeId attributeId, void *data, size_t dataSize);
 
 private:
 	CHIP_ERROR AddDevice(BridgedDevice *device);
 
 	static constexpr uint8_t kMaxBridgedDevices = CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
+	static constexpr uint8_t kMaxDataProviders = CONFIG_BRIDGE_MAX_BRIDGED_DEVICES_NUMBER;
 
+	/* TODO: Implement lightweight map to decrease flash usage. */
+	std::map<BridgedDevice *, BridgedDeviceDataProvider *> mDevicesMap;
 	BridgedDevice *mBridgedDevices[kMaxBridgedDevices];
+	BridgedDeviceDataProvider *mDataProviders[kMaxDataProviders];
 
 	chip::EndpointId mFirstDynamicEndpointId;
 	chip::EndpointId mCurrentDynamicEndpointId;

--- a/samples/matter/bridge/src/bridged_device.cpp
+++ b/samples/matter/bridge/src/bridged_device.cpp
@@ -10,7 +10,7 @@
 using namespace ::chip;
 using namespace ::chip::app;
 
-CHIP_ERROR BridgedDevice::HandleReadAttribute(void *attribute, size_t attributeSize, uint8_t *buffer,
+CHIP_ERROR BridgedDevice::CopyAttribute(void *attribute, size_t attributeSize, void *buffer,
 					      uint16_t maxBufferSize)
 {
 	if (maxBufferSize < attributeSize) {
@@ -28,7 +28,7 @@ CHIP_ERROR BridgedDevice::HandleReadBridgedDeviceBasicInformation(AttributeId at
 	switch (attributeId) {
 	case Clusters::BridgedDeviceBasicInformation::Attributes::Reachable::Id: {
 		bool isReachable = GetIsReachable();
-		return HandleReadAttribute(&isReachable, sizeof(isReachable), buffer, maxReadLength);
+		return CopyAttribute(&isReachable, sizeof(isReachable), buffer, maxReadLength);
 	}
 	case Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id: {
 		MutableByteSpan zclNodeLabelSpan(buffer, maxReadLength);
@@ -36,11 +36,11 @@ CHIP_ERROR BridgedDevice::HandleReadBridgedDeviceBasicInformation(AttributeId at
 	}
 	case Clusters::BridgedDeviceBasicInformation::Attributes::ClusterRevision::Id: {
 		uint16_t clusterRevision = GetBridgedDeviceBasicInformationClusterRevision();
-		return HandleReadAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
+		return CopyAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
 	}
 	case Clusters::BridgedDeviceBasicInformation::Attributes::FeatureMap::Id: {
 		uint32_t featureMap = GetBridgedDeviceBasicInformationFeatureMap();
-		return HandleReadAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
+		return CopyAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
 	}
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
@@ -52,11 +52,11 @@ CHIP_ERROR BridgedDevice::HandleReadDescriptor(AttributeId attributeId, uint8_t 
 	switch (attributeId) {
 	case Clusters::Descriptor::Attributes::ClusterRevision::Id: {
 		uint16_t clusterRevision = GetDescriptorClusterRevision();
-		return HandleReadAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
+		return CopyAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
 	}
 	case Clusters::Descriptor::Attributes::FeatureMap::Id: {
 		uint32_t featureMap = GetDescriptorFeatureMap();
-		return HandleReadAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
+		return CopyAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
 	}
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;

--- a/samples/matter/bridge/src/bridged_device.h
+++ b/samples/matter/bridge/src/bridged_device.h
@@ -63,7 +63,9 @@ public:
 	virtual CHIP_ERROR HandleRead(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer,
 				      uint16_t maxReadLength) = 0;
 	virtual CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) = 0;
-	CHIP_ERROR HandleReadAttribute(void *attribute, size_t attributeSize, uint8_t *buffer, uint16_t maxBufferSize);
+	virtual CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+						 size_t dataSize) = 0;
+	CHIP_ERROR CopyAttribute(void *attribute, size_t attributeSize, void *buffer, uint16_t maxBufferSize);
 	CHIP_ERROR HandleReadBridgedDeviceBasicInformation(chip::AttributeId attributeId, uint8_t *buffer,
 							   uint16_t maxReadLength);
 	CHIP_ERROR HandleReadDescriptor(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
@@ -83,6 +85,8 @@ public:
 	size_t mDeviceTypeListSize;
 	chip::DataVersion *mDataVersion;
 	size_t mDataVersionSize;
+
+protected:
 	chip::EndpointId mEndpointId;
 
 private:

--- a/samples/matter/bridge/src/bridged_device_data_provider.h
+++ b/samples/matter/bridge/src/bridged_device_data_provider.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <app/util/attribute-storage.h>
+
+class BridgedDeviceDataProvider {
+public:
+	using UpdateAttributeCallback = void (*)(BridgedDeviceDataProvider &dataProvider, chip::ClusterId clusterId,
+						 chip::AttributeId attributeId, void *data, size_t dataSize);
+
+	explicit BridgedDeviceDataProvider(UpdateAttributeCallback callback) { mUpdateAttributeCallback = callback; }
+
+	virtual void Init() = 0;
+	virtual void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+				       size_t dataSize) = 0;
+	virtual CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) = 0;
+
+protected:
+	UpdateAttributeCallback mUpdateAttributeCallback;
+};

--- a/samples/matter/bridge/src/bridged_device_types/humidity_sensor.cpp
+++ b/samples/matter/bridge/src/bridged_device_types/humidity_sensor.cpp
@@ -10,7 +10,7 @@ namespace
 {
 DESCRIPTOR_CLUSTER_ATTRIBUTES(descriptorAttrs);
 BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_ATTRIBUTES(bridgedDeviceBasicAttrs);
-}; // namespace
+}; /* namespace */
 
 using namespace ::chip;
 using namespace ::chip::app;
@@ -74,25 +74,81 @@ CHIP_ERROR HumiditySensorDevice::HandleReadRelativeHumidityMeasurement(Attribute
 	switch (attributeId) {
 	case Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id: {
 		uint16_t value = GetMeasuredValue();
-		return HandleReadAttribute(&value, sizeof(value), buffer, maxReadLength);
+		return CopyAttribute(&value, sizeof(value), buffer, maxReadLength);
 	}
 	case Clusters::RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Id: {
 		uint16_t value = GetMinMeasuredValue();
-		return HandleReadAttribute(&value, sizeof(value), buffer, maxReadLength);
+		return CopyAttribute(&value, sizeof(value), buffer, maxReadLength);
 	}
 	case Clusters::RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Id: {
 		uint16_t value = GetMaxMeasuredValue();
-		return HandleReadAttribute(&value, sizeof(value), buffer, maxReadLength);
+		return CopyAttribute(&value, sizeof(value), buffer, maxReadLength);
 	}
 	case Clusters::RelativeHumidityMeasurement::Attributes::ClusterRevision::Id: {
 		uint16_t clusterRevision = GetRelativeHumidityMeasurementClusterRevision();
-		return HandleReadAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
+		return CopyAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
 	}
 	case Clusters::RelativeHumidityMeasurement::Attributes::FeatureMap::Id: {
 		uint32_t featureMap = GetRelativeHumidityMeasurementFeatureMap();
-		return HandleReadAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
+		return CopyAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
 	}
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
+}
+
+CHIP_ERROR HumiditySensorDevice::HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId,
+						       void *data, size_t dataSize)
+{
+	if (clusterId != Clusters::RelativeHumidityMeasurement::Id || !data) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	CHIP_ERROR err;
+
+	switch (attributeId) {
+	case Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id: {
+		int16_t value;
+
+		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+
+		if (err != CHIP_NO_ERROR) {
+			return err;
+		}
+
+		SetMeasuredValue(value);
+
+		break;
+	}
+	case Clusters::RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Id: {
+		int16_t value;
+
+		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+
+		if (err != CHIP_NO_ERROR) {
+			return err;
+		}
+
+		SetMinMeasuredValue(value);
+
+		break;
+	}
+	case Clusters::RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Id: {
+		int16_t value;
+
+		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+
+		if (err != CHIP_NO_ERROR) {
+			return err;
+		}
+
+		SetMaxMeasuredValue(value);
+
+		break;
+	}
+	default:
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	return err;
 }

--- a/samples/matter/bridge/src/bridged_device_types/humidity_sensor.h
+++ b/samples/matter/bridge/src/bridged_device_types/humidity_sensor.h
@@ -10,6 +10,9 @@
 
 class HumiditySensorDevice : public BridgedDevice {
 public:
+	static constexpr uint16_t kRelativeHumidityMeasurementClusterRevision = 1;
+	static constexpr uint32_t kRelativeHumidityMeasurementFeatureMap = 0;
+
 	HumiditySensorDevice(const char *nodeLabel);
 
 	uint16_t GetMeasuredValue() { return mMeasuredValue; }
@@ -26,12 +29,15 @@ public:
 	{
 		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}
+	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+					 size_t dataSize) override;
 
 private:
-	static constexpr uint16_t kRelativeHumidityMeasurementClusterRevision = 1;
-	static constexpr uint32_t kRelativeHumidityMeasurementFeatureMap = 0;
+	void SetMeasuredValue(int16_t value) { mMeasuredValue = value; }
+	void SetMinMeasuredValue(int16_t value) { mMinMeasuredValue = value; }
+	void SetMaxMeasuredValue(int16_t value) { mMaxMeasuredValue = value; }
 
-	uint16_t mMeasuredValue = 50;
-	uint16_t mMinMeasuredValue = 0;
-	uint16_t mMaxMeasuredValue = 100;
+	uint16_t mMeasuredValue = 0;
+	uint16_t mMinMeasuredValue = CONFIG_BRIDGE_HUMIDITY_SENSOR_MIN_MEASURED_VALUE;
+	uint16_t mMaxMeasuredValue = CONFIG_BRIDGE_HUMIDITY_SENSOR_MAX_MEASURED_VALUE;
 };

--- a/samples/matter/bridge/src/bridged_device_types/humidity_sensor_data_provider.cpp
+++ b/samples/matter/bridge/src/bridged_device_types/humidity_sensor_data_provider.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "humidity_sensor_data_provider.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
+
+using namespace ::chip;
+using namespace ::chip::app;
+
+void HumiditySensorDataProvider::Init()
+{
+	k_timer_init(&mTimer, HumiditySensorDataProvider::TimerTimeoutCallback, nullptr);
+	k_timer_user_data_set(&mTimer, this);
+	k_timer_start(&mTimer, K_MSEC(kMeasurementsIntervalMs), K_MSEC(kMeasurementsIntervalMs));
+}
+
+void HumiditySensorDataProvider::NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+						   size_t dataSize)
+{
+	if (mUpdateAttributeCallback) {
+		mUpdateAttributeCallback(*this, Clusters::RelativeHumidityMeasurement::Id,
+					 Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id, data,
+					 dataSize);
+	}
+}
+
+CHIP_ERROR HumiditySensorDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
+						   uint8_t *buffer)
+{
+	return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+void HumiditySensorDataProvider::TimerTimeoutCallback(k_timer *timer)
+{
+	if (!timer || !timer->user_data) {
+		return;
+	}
+
+	HumiditySensorDataProvider *provider = reinterpret_cast<HumiditySensorDataProvider *>(timer->user_data);
+
+	/* Get some random data to emulate sensor measurements. */
+	provider->mHumidity =
+		chip::Crypto::GetRandU16() % (kMaxRandomTemperature - kMinRandomTemperature) + kMinRandomTemperature;
+
+	LOG_INF("HumiditySensorDataProvider: Updated humidity value to %d", provider->mHumidity);
+
+	DeviceLayer::PlatformMgr().ScheduleWork(NotifyAttributeChange, reinterpret_cast<intptr_t>(provider));
+}
+
+void HumiditySensorDataProvider::NotifyAttributeChange(intptr_t context)
+{
+	HumiditySensorDataProvider *provider = reinterpret_cast<HumiditySensorDataProvider *>(context);
+
+	provider->NotifyUpdateState(Clusters::RelativeHumidityMeasurement::Id,
+				    Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::Id,
+				    &provider->mHumidity, sizeof(provider->mHumidity));
+}

--- a/samples/matter/bridge/src/bridged_device_types/humidity_sensor_data_provider.h
+++ b/samples/matter/bridge/src/bridged_device_types/humidity_sensor_data_provider.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "bridged_device_data_provider.h"
+
+class HumiditySensorDataProvider : public BridgedDeviceDataProvider {
+public:
+	static constexpr uint16_t kMeasurementsIntervalMs = 10000;
+	static constexpr uint16_t kMinRandomTemperature = 30;
+	static constexpr uint16_t kMaxRandomTemperature = 50;
+
+	HumiditySensorDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
+
+	void Init() override;
+	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+			       size_t dataSize) override;
+	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
+
+	static void TimerTimeoutCallback(k_timer *timer);
+	static void NotifyAttributeChange(intptr_t context);
+
+private:
+	k_timer mTimer;
+	uint16_t mHumidity = 0;
+};

--- a/samples/matter/bridge/src/bridged_device_types/onoff_light.h
+++ b/samples/matter/bridge/src/bridged_device_types/onoff_light.h
@@ -10,9 +10,11 @@
 
 class OnOffLightDevice : public BridgedDevice {
 public:
+	static constexpr uint16_t kOnOffClusterRevision = 1;
+	static constexpr uint32_t kOnOffFeatureMap = 0;
+
 	OnOffLightDevice(const char *nodeLabel);
 
-	void Set(bool onOff) { mOnOff = onOff; }
 	bool GetOnOff() { return mOnOff; }
 	void Toggle() { mOnOff = !mOnOff; }
 	uint16_t GetOnOffClusterRevision() { return kOnOffClusterRevision; }
@@ -22,10 +24,11 @@ public:
 			      uint16_t maxReadLength) override;
 	CHIP_ERROR HandleReadOnOff(chip::AttributeId attributeId, uint8_t *buffer, uint16_t maxReadLength);
 	CHIP_ERROR HandleWrite(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
+	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+					 size_t dataSize) override;
 
 private:
-	static constexpr uint16_t kOnOffClusterRevision = 1;
-	static constexpr uint32_t kOnOffFeatureMap = 0;
+	void SetOnOff(bool onOff) { mOnOff = onOff; }
 
 	bool mOnOff = false;
 };

--- a/samples/matter/bridge/src/bridged_device_types/onoff_light_data_provider.cpp
+++ b/samples/matter/bridge/src/bridged_device_types/onoff_light_data_provider.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "onoff_light_data_provider.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
+
+using namespace ::chip;
+using namespace ::chip::app;
+
+void OnOffLightDataProvider::Init()
+{
+	k_timer_init(&mTimer, OnOffLightDataProvider::TimerTimeoutCallback, nullptr);
+	k_timer_user_data_set(&mTimer, this);
+	k_timer_start(&mTimer, K_MSEC(kOnOffIntervalMs), K_MSEC(kOnOffIntervalMs));
+}
+
+void OnOffLightDataProvider::NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+					       size_t dataSize)
+{
+	if (mUpdateAttributeCallback) {
+		mUpdateAttributeCallback(*this, Clusters::OnOff::Id, Clusters::OnOff::Attributes::OnOff::Id, data,
+					 dataSize);
+	}
+}
+
+CHIP_ERROR OnOffLightDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
+					       uint8_t *buffer)
+{
+	if (clusterId != Clusters::OnOff::Id) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	switch (attributeId) {
+	case Clusters::OnOff::Attributes::OnOff::Id: {
+		mOnOff = *buffer;
+		NotifyUpdateState(clusterId, attributeId, &mOnOff, sizeof(mOnOff));
+		return CHIP_NO_ERROR;
+	}
+	default:
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	return CHIP_NO_ERROR;
+}
+
+void OnOffLightDataProvider::TimerTimeoutCallback(k_timer *timer)
+{
+	if (!timer || !timer->user_data) {
+		return;
+	}
+
+	OnOffLightDataProvider *provider = reinterpret_cast<OnOffLightDataProvider *>(timer->user_data);
+
+	/* Toggle light state to emulate user's manual interactions. */
+	provider->mOnOff = !provider->mOnOff;
+
+	LOG_INF("OnOffLightDataProvider: Updated light state to %d", provider->mOnOff);
+
+	DeviceLayer::PlatformMgr().ScheduleWork(NotifyAttributeChange, reinterpret_cast<intptr_t>(provider));
+}
+
+void OnOffLightDataProvider::NotifyAttributeChange(intptr_t context)
+{
+	OnOffLightDataProvider *provider = reinterpret_cast<OnOffLightDataProvider *>(context);
+
+	provider->NotifyUpdateState(Clusters::OnOff::Id, Clusters::OnOff::Attributes::OnOff::Id, &provider->mOnOff,
+				    sizeof(provider->mOnOff));
+}

--- a/samples/matter/bridge/src/bridged_device_types/onoff_light_data_provider.h
+++ b/samples/matter/bridge/src/bridged_device_types/onoff_light_data_provider.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "bridged_device_data_provider.h"
+
+class OnOffLightDataProvider : public BridgedDeviceDataProvider {
+public:
+	static constexpr uint16_t kOnOffIntervalMs = 30000;
+
+	OnOffLightDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
+
+	void Init() override;
+	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+			       size_t dataSize) override;
+	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
+
+	static void TimerTimeoutCallback(k_timer *timer);
+	static void NotifyAttributeChange(intptr_t context);
+
+private:
+	k_timer mTimer;
+	bool mOnOff = false;
+};

--- a/samples/matter/bridge/src/bridged_device_types/temperature_sensor.cpp
+++ b/samples/matter/bridge/src/bridged_device_types/temperature_sensor.cpp
@@ -10,7 +10,7 @@ namespace
 {
 DESCRIPTOR_CLUSTER_ATTRIBUTES(descriptorAttrs);
 BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_ATTRIBUTES(bridgedDeviceBasicAttrs);
-}; // namespace
+}; /* namespace */
 
 using namespace ::chip;
 using namespace ::chip::app;
@@ -72,25 +72,80 @@ CHIP_ERROR TemperatureSensorDevice::HandleReadTemperatureMeasurement(AttributeId
 	switch (attributeId) {
 	case Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id: {
 		int16_t value = GetMeasuredValue();
-		return HandleReadAttribute(&value, sizeof(value), buffer, maxReadLength);
+		return CopyAttribute(&value, sizeof(value), buffer, maxReadLength);
 	}
 	case Clusters::TemperatureMeasurement::Attributes::MinMeasuredValue::Id: {
 		int16_t value = GetMinMeasuredValue();
-		return HandleReadAttribute(&value, sizeof(value), buffer, maxReadLength);
+		return CopyAttribute(&value, sizeof(value), buffer, maxReadLength);
 	}
 	case Clusters::TemperatureMeasurement::Attributes::MaxMeasuredValue::Id: {
 		int16_t value = GetMaxMeasuredValue();
-		return HandleReadAttribute(&value, sizeof(value), buffer, maxReadLength);
+		return CopyAttribute(&value, sizeof(value), buffer, maxReadLength);
 	}
 	case Clusters::TemperatureMeasurement::Attributes::ClusterRevision::Id: {
 		uint16_t clusterRevision = GetTemperatureMeasurementClusterRevision();
-		return HandleReadAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
+		return CopyAttribute(&clusterRevision, sizeof(clusterRevision), buffer, maxReadLength);
 	}
 	case Clusters::TemperatureMeasurement::Attributes::FeatureMap::Id: {
 		uint32_t featureMap = GetTemperatureMeasurementFeatureMap();
-		return HandleReadAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
+		return CopyAttribute(&featureMap, sizeof(featureMap), buffer, maxReadLength);
 	}
 	default:
 		return CHIP_ERROR_INVALID_ARGUMENT;
 	}
+}
+
+CHIP_ERROR TemperatureSensorDevice::HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId,
+							  void *data, size_t dataSize)
+{
+	if (clusterId != Clusters::TemperatureMeasurement::Id || !data) {
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+
+	CHIP_ERROR err;
+
+	switch (attributeId) {
+	case Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id: {
+		int16_t value;
+
+		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+
+		if (err != CHIP_NO_ERROR) {
+			return err;
+		}
+
+		SetMeasuredValue(value);
+
+		break;
+	}
+	case Clusters::TemperatureMeasurement::Attributes::MinMeasuredValue::Id: {
+		int16_t value;
+
+		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+
+		if (err != CHIP_NO_ERROR) {
+			return err;
+		}
+
+		SetMinMeasuredValue(value);
+
+		break;
+	}
+	case Clusters::TemperatureMeasurement::Attributes::MaxMeasuredValue::Id: {
+		int16_t value;
+
+		err = CopyAttribute(data, dataSize, &value, sizeof(value));
+
+		if (err != CHIP_NO_ERROR) {
+			return err;
+		}
+
+		SetMaxMeasuredValue(value);
+
+		break;
+	}
+	default:
+		return CHIP_ERROR_INVALID_ARGUMENT;
+	}
+	return err;
 }

--- a/samples/matter/bridge/src/bridged_device_types/temperature_sensor.h
+++ b/samples/matter/bridge/src/bridged_device_types/temperature_sensor.h
@@ -10,6 +10,9 @@
 
 class TemperatureSensorDevice : public BridgedDevice {
 public:
+	static constexpr uint16_t kTemperatureMeasurementClusterRevision = 1;
+	static constexpr uint32_t kTemperatureMeasurementFeatureMap = 0;
+
 	TemperatureSensorDevice(const char *nodeLabel);
 
 	int16_t GetMeasuredValue() { return mMeasuredValue; }
@@ -26,12 +29,15 @@ public:
 	{
 		return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 	}
+	CHIP_ERROR HandleAttributeChange(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+					 size_t dataSize) override;
 
 private:
-	static constexpr uint16_t kTemperatureMeasurementClusterRevision = 1;
-	static constexpr uint32_t kTemperatureMeasurementFeatureMap = 0;
+	void SetMeasuredValue(int16_t value) { mMeasuredValue = value; }
+	void SetMinMeasuredValue(int16_t value) { mMinMeasuredValue = value; }
+	void SetMaxMeasuredValue(int16_t value) { mMaxMeasuredValue = value; }
 
-	int16_t mMeasuredValue = 20;
-	int16_t mMinMeasuredValue = -10;
-	int16_t mMaxMeasuredValue = 40;
+	int16_t mMeasuredValue = 0;
+	int16_t mMinMeasuredValue = CONFIG_BRIDGE_TEMPERATURE_SENSOR_MIN_MEASURED_VALUE;
+	int16_t mMaxMeasuredValue = CONFIG_BRIDGE_TEMPERATURE_SENSOR_MAX_MEASURED_VALUE;
 };

--- a/samples/matter/bridge/src/bridged_device_types/temperature_sensor_data_provider.cpp
+++ b/samples/matter/bridge/src/bridged_device_types/temperature_sensor_data_provider.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "temperature_sensor_data_provider.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
+
+using namespace ::chip;
+using namespace ::chip::app;
+
+void TemperatureSensorDataProvider::Init()
+{
+	k_timer_init(&mTimer, TemperatureSensorDataProvider::TimerTimeoutCallback, nullptr);
+	k_timer_user_data_set(&mTimer, this);
+	k_timer_start(&mTimer, K_MSEC(kMeasurementsIntervalMs), K_MSEC(kMeasurementsIntervalMs));
+}
+
+void TemperatureSensorDataProvider::NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
+						      void *data, size_t dataSize)
+{
+	if (mUpdateAttributeCallback) {
+		mUpdateAttributeCallback(*this, Clusters::TemperatureMeasurement::Id,
+					 Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id, data,
+					 dataSize);
+	}
+}
+
+CHIP_ERROR TemperatureSensorDataProvider::UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId,
+						      uint8_t *buffer)
+{
+	return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+void TemperatureSensorDataProvider::TimerTimeoutCallback(k_timer *timer)
+{
+	if (!timer || !timer->user_data) {
+		return;
+	}
+
+	TemperatureSensorDataProvider *provider = reinterpret_cast<TemperatureSensorDataProvider *>(timer->user_data);
+
+	/* Get some random data to emulate sensor measurements. */
+	provider->mTemperature =
+		chip::Crypto::GetRandU16() % (kMaxRandomTemperature - kMinRandomTemperature) + kMinRandomTemperature;
+
+	LOG_INF("TemperatureSensorDataProvider: Updated temperature value to %d", provider->mTemperature);
+
+	DeviceLayer::PlatformMgr().ScheduleWork(NotifyAttributeChange, reinterpret_cast<intptr_t>(provider));
+}
+
+void TemperatureSensorDataProvider::NotifyAttributeChange(intptr_t context)
+{
+	TemperatureSensorDataProvider *provider = reinterpret_cast<TemperatureSensorDataProvider *>(context);
+
+	provider->NotifyUpdateState(Clusters::TemperatureMeasurement::Id,
+				    Clusters::TemperatureMeasurement::Attributes::MeasuredValue::Id,
+				    &provider->mTemperature, sizeof(provider->mTemperature));
+}

--- a/samples/matter/bridge/src/bridged_device_types/temperature_sensor_data_provider.h
+++ b/samples/matter/bridge/src/bridged_device_types/temperature_sensor_data_provider.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include "bridged_device_data_provider.h"
+
+#include <zephyr/kernel.h>
+
+class TemperatureSensorDataProvider : public BridgedDeviceDataProvider {
+public:
+	static constexpr uint16_t kMeasurementsIntervalMs = 10000;
+	static constexpr int16_t kMinRandomTemperature = -10;
+	static constexpr int16_t kMaxRandomTemperature = 10;
+
+	TemperatureSensorDataProvider(UpdateAttributeCallback callback) : BridgedDeviceDataProvider(callback) {}
+
+	void Init() override;
+	void NotifyUpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, void *data,
+			       size_t dataSize) override;
+	CHIP_ERROR UpdateState(chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t *buffer) override;
+
+	static void TimerTimeoutCallback(k_timer *timer);
+	static void NotifyAttributeChange(intptr_t context);
+
+private:
+	k_timer mTimer;
+	int16_t mTemperature = 0;
+};


### PR DESCRIPTION
* Implemented BridgedDeviceDataProvider module to describe a non-Matter device data object in bridge.
* Created a map to describe relationship between bridged devices and data providers.
* Added support for subscriptions handling
* Implemented example data providers for OnOff, TemperatureMeasurement and HumidityMeasurement devices.